### PR TITLE
Move out CA/license code from Telekube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+#
+# test runs package tests
+#
+.PHONY: test
+test:
+	go test -v -test.parallel=0 -race ./...

--- a/authority/ca.go
+++ b/authority/ca.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package authority implements X509 certificate authority features
+package authority
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/x509"
+	"io/ioutil"
+	"time"
+
+	"github.com/gravitational/license/constants"
+
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/initca"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/cloudflare/cfssl/signer/local"
+	"github.com/gravitational/trace"
+)
+
+// TLSKeyPair is a pair with TLS private key and certificate
+type TLSKeyPair struct {
+	// KeyPEM is private key PEM encoded contents
+	KeyPEM []byte
+	// CertPEM is certificate PEM encoded contents
+	CertPEM []byte
+}
+
+// NewTLSKeyPair returns a new TLSKeyPair with private key and certificate found
+// at the provided paths
+func NewTLSKeyPair(keyPath, certPath string) (*TLSKeyPair, error) {
+	keyBytes, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	certBytes, err := ioutil.ReadFile(certPath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &TLSKeyPair{
+		KeyPEM:  keyBytes,
+		CertPEM: certBytes,
+	}, nil
+}
+
+// GenerateSelfSignedCA generates self signed certificate authority
+func GenerateSelfSignedCA(req csr.CertificateRequest) (*TLSKeyPair, error) {
+	if req.KeyRequest == nil {
+		req.KeyRequest = &csr.BasicKeyRequest{
+			A: constants.TLSKeyAlgo,
+			S: constants.TLSKeySize,
+		}
+	}
+	cert, _, key, err := initca.New(&req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &TLSKeyPair{
+		KeyPEM:  key,
+		CertPEM: cert,
+	}, nil
+}
+
+// ProcessCSR processes CSR (certificate sign request) with given cert authority
+func ProcessCSR(req signer.SignRequest, ttl time.Duration, certAuthority *TLSKeyPair) ([]byte, error) {
+	s, err := getSigner(certAuthority, ttl)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cert, err := s.Sign(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return cert, nil
+}
+
+// GenerateCertificate generates a certificate/key pair signed by the provided CA,
+// if privateKeyPEM is provided, uses the key instead of generating it
+func GenerateCertificate(req csr.CertificateRequest, certAuthority *TLSKeyPair, privateKeyPEM []byte, validFor time.Duration) (*TLSKeyPair, error) {
+	return GenerateCertificateWithExtensions(req, certAuthority, privateKeyPEM, validFor, nil)
+}
+
+// GenerateCertificateWithExtensions is like GenerateCertificate but allows to specify
+// extensions to include into generated certificate
+func GenerateCertificateWithExtensions(req csr.CertificateRequest, certAuthority *TLSKeyPair, privateKeyPEM []byte, validFor time.Duration, extensions []signer.Extension) (*TLSKeyPair, error) {
+	s, err := getSigner(certAuthority, validFor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	csrBytes, key, err := GenerateCSR(req, privateKeyPEM)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var cert []byte
+	signRequest := signer.SignRequest{
+		Subject: &signer.Subject{
+			CN:    req.CN,
+			Names: req.Names,
+		},
+		Request:    string(csrBytes),
+		Hosts:      req.Hosts,
+		Extensions: extensions,
+	}
+
+	cert, err = s.Sign(signRequest)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &TLSKeyPair{
+		CertPEM: cert,
+		KeyPEM:  key,
+	}, nil
+}
+
+// GenerateCSR generates new certificate signing request for existing key if supplied
+// or generates new private key otherwise
+func GenerateCSR(req csr.CertificateRequest, privateKeyPEM []byte) (csrBytes []byte, key []byte, err error) {
+	generator := &csr.Generator{
+		Validator: func(req *csr.CertificateRequest) error {
+			return nil
+		},
+	}
+	if len(privateKeyPEM) != 0 {
+		existingKey, err := NewExistingKey(privateKeyPEM)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		req.KeyRequest = existingKey
+	} else {
+		req.KeyRequest = &csr.BasicKeyRequest{
+			A: constants.TLSKeyAlgo,
+			S: constants.TLSKeySize,
+		}
+	}
+
+	csrBytes, key, err = generator.ProcessRequest(&req)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return csrBytes, key, nil
+}
+
+// getSigner returns signer from TLSKeyPair assuming that keypair is a valid X509 certificate authority
+func getSigner(certAuthority *TLSKeyPair, validFor time.Duration) (signer.Signer, error) {
+	cert, err := helpers.ParseCertificatePEM(certAuthority.CertPEM)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	key, err := helpers.ParsePrivateKeyPEM(certAuthority.KeyPEM)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	profile := config.DefaultConfig()
+
+	// whitelist our custom extension where encoded license payload will go
+	profile.ExtensionWhitelist = map[string]bool{
+		constants.LicenseASN1ExtensionID.String(): true,
+	}
+
+	// the default profile has 1 year expiration time, override it if it was provided
+	if validFor != 0 {
+		profile.NotAfter = time.Now().Add(validFor).UTC()
+	}
+
+	// set "not before" in the past to alleviate skewed clock issues
+	profile.NotBefore = time.Now().Add(-time.Hour).UTC()
+
+	policy := &config.Signing{
+		Default: profile,
+	}
+
+	return local.NewSigner(key, cert, signer.DefaultSigAlgo(key), policy)
+}
+
+// ExistingKey tells signer to use existing key instead
+type ExistingKey struct {
+	key *rsa.PrivateKey
+}
+
+func NewExistingKey(keyPEM []byte) (*ExistingKey, error) {
+	key, err := helpers.ParsePrivateKeyPEMWithPassword(keyPEM, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	rkey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, trace.BadParameter("only RSA keys supported, got %T", key)
+	}
+	return &ExistingKey{key: rkey}, nil
+}
+
+// Algo returns the requested key algorithm represented as a string.
+func (kr *ExistingKey) Algo() string {
+	return "rsa"
+}
+
+// Size returns the requested key size.
+func (kr *ExistingKey) Size() int {
+	return kr.key.N.BitLen()
+}
+
+// Generate generates a key as specified in the request. Currently,
+// only ECDSA and RSA are supported.
+func (kr *ExistingKey) Generate() (crypto.PrivateKey, error) {
+	return kr.key, nil
+}
+
+// SigAlgo returns an appropriate X.509 signature algorithm given the
+// key request's type and size.
+func (kr *ExistingKey) SigAlgo() x509.SignatureAlgorithm {
+	switch {
+	case kr.Size() >= 4096:
+		return x509.SHA512WithRSA
+	case kr.Size() >= 3072:
+		return x509.SHA384WithRSA
+	case kr.Size() >= 2048:
+		return x509.SHA256WithRSA
+	default:
+		return x509.SHA1WithRSA
+	}
+}

--- a/authority/ca_test.go
+++ b/authority/ca_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authority
+
+import (
+	"testing"
+
+	"github.com/cloudflare/cfssl/csr"
+	. "gopkg.in/check.v1"
+)
+
+func TestCA(t *testing.T) { TestingT(t) }
+
+type CASuite struct{}
+
+var _ = Suite(&CASuite{})
+
+func (s *CASuite) TestCertLifecycle(c *C) {
+	ca, err := GenerateSelfSignedCA(csr.CertificateRequest{
+		CN: "cluster.local",
+	})
+	c.Assert(err, IsNil)
+	c.Assert(ca, NotNil)
+
+	keyPair, err := GenerateCertificate(csr.CertificateRequest{
+		CN:    "apiserver",
+		Hosts: []string{"127.0.0.1"},
+		Names: []csr.Name{
+			{
+				O:  "Gravitational",
+				OU: "Local Cluster",
+			},
+		},
+	}, ca, nil, 0)
+
+	c.Assert(err, IsNil)
+	c.Assert(keyPair, NotNil)
+
+	keyPair2, err := GenerateCertificate(csr.CertificateRequest{
+		CN:    "apiserver",
+		Hosts: []string{"127.0.0.2"},
+		Names: []csr.Name{
+			{
+				O:  "Gravitational",
+				OU: "Local Cluster",
+			},
+		},
+	}, ca, keyPair.KeyPEM, 0)
+
+	c.Assert(err, IsNil)
+	c.Assert(keyPair2, NotNil)
+
+	c.Assert(string(keyPair.KeyPEM), DeepEquals, string(keyPair2.KeyPEM))
+	c.Assert(string(keyPair.CertPEM), Not(Equals), string(keyPair2.CertPEM))
+}

--- a/certificate.go
+++ b/certificate.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"time"
+
+	"github.com/gravitational/license/authority"
+	"github.com/gravitational/license/constants"
+
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/gravitational/trace"
+)
+
+func newCertificate(data NewLicenseInfo) ([]byte, error) {
+	private, err := rsa.GenerateKey(rand.Reader, constants.LicenseKeyBits)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	privatePEM := pem.EncodeToMemory(&pem.Block{
+		Type:  constants.RSAPrivateKeyPEMBlock,
+		Bytes: x509.MarshalPKCS1PrivateKey(private),
+	})
+
+	// encrypt encryption key
+	var encryptedKey []byte
+	if len(data.EncryptionKey) != 0 {
+		encryptedKey, err = rsa.EncryptOAEP(sha256.New(), rand.Reader,
+			private.Public().(*rsa.PublicKey), data.EncryptionKey, nil)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	payload := Payload{
+		MaxNodes:       data.MaxNodes,
+		Expiration:     time.Now().UTC().Add(data.ValidFor),
+		Shutdown:       data.StopApp,
+		Person:         data.CustomerName,
+		Email:          data.CustomerEmail,
+		Metadata:       data.CustomerMetadata,
+		ProductName:    data.ProductName,
+		ProductVersion: data.ProductVersion,
+		EncryptionKey:  encryptedKey,
+	}
+	bytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// make an extension to encode into certificate
+	extensions := []signer.Extension{{
+		ID:    config.OID(constants.LicenseASN1ExtensionID),
+		Value: hex.EncodeToString(bytes),
+	}}
+
+	req := csr.CertificateRequest{
+		CN:    constants.LicenseKeyPair,
+		Hosts: []string{constants.LoopbackIP},
+		Names: []csr.Name{{
+			O: constants.LicenseOrg,
+		}},
+	}
+
+	// generate certificate signed by the provided certificate authority
+	tlsKeyPair, err := authority.GenerateCertificateWithExtensions(
+		req, &data.TLSKeyPair, privatePEM, data.ValidFor, extensions)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return append(tlsKeyPair.CertPEM, tlsKeyPair.KeyPEM...), nil
+}
+
+// parseCertificate parses the provided license string in PEM format
+func parseCertificate(certPEM string) (License, error) {
+	// parse the certificate and private key
+	certificateBytes, privateBytes, err := parseCertificatePEM(certPEM)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	certificate, err := x509.ParseCertificate(certificateBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// parse the extension
+	var p *Payload
+	for _, ext := range certificate.Extensions {
+		if ext.Id.Equal(constants.LicenseASN1ExtensionID) {
+			p = new(Payload)
+			if err := json.Unmarshal(ext.Value, p); err != nil {
+				return nil, trace.Wrap(err)
+			}
+			break
+		}
+	}
+	if p == nil {
+		return nil, trace.BadParameter("could not find payload extension")
+	}
+
+	// decrypt encryption key
+	if len(p.EncryptionKey) != 0 {
+		private, err := x509.ParsePKCS1PrivateKey(privateBytes)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		p.EncryptionKey, err = rsa.DecryptOAEP(sha256.New(), rand.Reader,
+			private, p.EncryptionKey, nil)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return &license{
+		certificate: certificate,
+		payload:     *p,
+	}, nil
+}
+
+// parseCertificatePEM parses the concatenated certificate/private key in PEM format
+// and returns certificate and private key in decoded DER ASN.1 structure
+func parseCertificatePEM(certPEM string) ([]byte, []byte, error) {
+	var certificateBytes, privateBytes []byte
+	block, rest := pem.Decode([]byte(certPEM))
+	for block != nil {
+		switch block.Type {
+		case constants.CertificatePEMBlock:
+			certificateBytes = block.Bytes
+		case constants.RSAPrivateKeyPEMBlock:
+			privateBytes = block.Bytes
+		}
+		// parse the next block
+		block, rest = pem.Decode(rest)
+	}
+	if len(certificateBytes) == 0 || len(privateBytes) == 0 {
+		return nil, nil, trace.BadParameter("could not parse the license")
+	}
+	return certificateBytes, privateBytes, nil
+}
+
+// license represents gravity license.
+type license struct {
+	certificate *x509.Certificate
+	payload     Payload
+}
+
+// Verify makes sure the certificate is valid.
+func (l *license) Verify(caPEM []byte) error {
+	roots := x509.NewCertPool()
+
+	// add the provided CA certificate to the roots
+	ok := roots.AppendCertsFromPEM(caPEM)
+	if !ok {
+		return trace.BadParameter("could not find any CA certificates")
+	}
+
+	_, err := l.certificate.Verify(x509.VerifyOptions{Roots: roots})
+	if err != nil {
+		certErr, ok := err.(x509.CertificateInvalidError)
+		if ok && certErr.Reason == x509.Expired {
+			return trace.BadParameter("the license has expired")
+		}
+		return trace.Wrap(err, "failed to verify the license")
+	}
+
+	return nil
+}
+
+// GetPayload returns payload.
+func (l *license) GetPayload() Payload {
+	return l.payload
+}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+import "encoding/asn1"
+
+const (
+	// TLSKeyAlgo is default TLS algo used for K8s X509 certs
+	TLSKeyAlgo = "rsa"
+
+	// TLSKeySize is default TLS key size used for K8s X509 certs
+	TLSKeySize = 2048
+
+	// RSAPrivateKeyPEMBlock is the name of the PEM block where private key is stored
+	RSAPrivateKeyPEMBlock = "RSA PRIVATE KEY"
+
+	// CertificatePEMBlock is the name of the PEM block where certificate is stored
+	CertificatePEMBlock = "CERTIFICATE"
+
+	// LicenseKeyPair is a name of the license key pair
+	LicenseKeyPair = "license"
+
+	// LoopbackIP is IP of the loopback interface
+	LoopbackIP = "127.0.0.1"
+
+	// LicenseKeyBits used when generating private key for license certificate
+	LicenseKeyBits = 2048
+
+	// LicenseOrg is the default name of license subject organization
+	LicenseOrg = "gravitational.io"
+
+	// LicenseTimeFormat represents format of expiration time in license payload
+	LicenseTimeFormat = "2006-01-02 15:04:05"
+)
+
+// LicenseASNExtensionID is an extension ID used when encoding/decoding
+// license payload into certificates
+var LicenseASN1ExtensionID = asn1.ObjectIdentifier{2, 5, 42}

--- a/license.go
+++ b/license.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gravitational/license/authority"
+
+	"github.com/gravitational/trace"
+)
+
+// License defines a common interface to support both gravity-generated and
+// customer licenses.
+type License interface {
+	// Verify verifies the license is valid.
+	Verify(caPEM []byte) error
+	// GetPayload returns various details encoded into licenses.
+	GetPayload() Payload
+}
+
+// NewLicenseInfo encapsulates fields needed to generate a license
+type NewLicenseInfo struct {
+	// MaxNodes is maximum number of nodes the license allows
+	MaxNodes int
+	// ValidFor is validity period for the license
+	ValidFor time.Duration
+	// StopApp indicates whether the app should be stopped when the license expires
+	StopApp bool
+	// CustomerName is the name of the customer the license is generated for
+	CustomerName string
+	// CustomerName is the email of the customer the license is generated for
+	CustomerEmail string
+	// CustomerMetadata is arbitrary metadata to add to the license
+	CustomerMetadata string
+	// ProductName is the name of the product the license is for
+	ProductName string
+	// ProductVersion is product version the license is for
+	ProductVersion string
+	// EncryptionKey is the passphrase for decoding encrypted packages
+	EncryptionKey []byte
+	// TLSKeyPair is the certificate authority to sign the license with
+	TLSKeyPair authority.TLSKeyPair
+}
+
+// Check checks the new license request
+func (i NewLicenseInfo) Check() error {
+	if i.MaxNodes < 1 {
+		return trace.BadParameter("maximum number of servers should be 1 or more")
+	}
+	if time.Now().Add(i.ValidFor).Before(time.Now()) {
+		return trace.BadParameter("expiration date can't be in the past")
+	}
+	if len(i.TLSKeyPair.CertPEM) == 0 {
+		return trace.BadParameter("certificate authority should be provided")
+	}
+	return nil
+}
+
+// NewLicense generates a new license according to the provided request.
+func NewLicense(info NewLicenseInfo) (string, error) {
+	err := info.Check()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	certificateBytes, err := newCertificate(info)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return string(certificateBytes), nil
+}
+
+// ParseLicense tries to detect the type of the provided license and parse it.
+func ParseLicense(license string) (License, error) {
+	if license == "" {
+		return Payload{}, nil
+	}
+	if strings.HasPrefix(license, "{") {
+		return parsePayload(license)
+	}
+	return parseCertificate(license)
+}
+
+// ParseLicenseByType tries to parse the provided license string as a license of
+// the specified type.
+func ParseLicenseByType(license, type_ string) (License, error) {
+	switch type_ {
+	case LicenseTypePayload:
+		return parsePayload(license)
+	case LicenseTypeCertificate:
+		return parseCertificate(license)
+	default:
+		return nil, trace.BadParameter("unknown license type: %v", type_)
+	}
+}
+
+const (
+	// LicenseTypeCertificate means that the license is a x509 certificate with encoded payload,
+	// this is the license normally used by deployments that rely on our own license
+	LicenseTypeCertificate = "certificate"
+	// LicenseTypePayload means that the license is the the payload itself with a signature,
+	// this is used by some vendors
+	LicenseTypePayload = "payload"
+)

--- a/license_test.go
+++ b/license_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gravitational/license/authority"
+	"github.com/gravitational/license/constants"
+
+	"github.com/cloudflare/cfssl/csr"
+	. "gopkg.in/check.v1"
+)
+
+func TestLicense(t *testing.T) { TestingT(t) }
+
+type LicenseSuite struct {
+	ca authority.TLSKeyPair
+}
+
+var _ = Suite(&LicenseSuite{})
+
+func (s *LicenseSuite) SetUpSuite(c *C) {
+	// generate certificate authority that will be used in tests
+	ca, err := authority.GenerateSelfSignedCA(csr.CertificateRequest{
+		CN: constants.LicenseKeyPair,
+	})
+	c.Assert(err, IsNil)
+	s.ca = *ca
+}
+
+func (s *LicenseSuite) TestLicense(c *C) {
+	dur, err := time.ParseDuration("1h")
+	c.Assert(err, IsNil)
+
+	// generate a new license
+	license, err := NewLicense(NewLicenseInfo{
+		MaxNodes:   3,
+		ValidFor:   dur,
+		StopApp:    false,
+		TLSKeyPair: s.ca,
+	})
+	c.Assert(err, IsNil)
+
+	// make sure we can parse it
+	parsed, err := ParseLicense(license)
+	c.Assert(err, IsNil)
+
+	// make sure it verifies successfully
+	c.Assert(parsed.Verify(s.ca.CertPEM), IsNil)
+
+	// make sure we can retrieve payload data
+	c.Assert(parsed.GetPayload().MaxNodes, Equals, 3)
+}
+
+func (s *LicenseSuite) TestCustomerLicense(c *C) {
+	// make sure we can parse customer license
+	parsed, err := ParseLicense(validLicense)
+	c.Assert(err, IsNil)
+
+	// make sure it verifies successfully
+	c.Assert(parsed.Verify(nil), IsNil)
+
+	// make sure we can retrieve payload data
+	c.Assert(parsed.GetPayload().ClusterID, Equals, "4fea07ba370f389b")
+	c.Assert(parsed.GetPayload().MaxNodes, Equals, 17)
+	c.Assert(parsed.GetPayload().MaxCores, Equals, 32)
+}
+
+func (s *LicenseSuite) TestExpiredLicense(c *C) {
+	// expired customer license
+	l, err := ParseLicense(expiredLicense)
+	c.Assert(err, IsNil)
+	c.Assert(l.Verify(nil), NotNil)
+}
+
+const (
+	validLicense   = `{"cluster_id": "4fea07ba370f389b", "expiration": "2020-12-31 00:00:00", "maxnodes": "17", "maxcores": "32"}`
+	expiredLicense = `{"cluster_id": "4fea07ba370f389b", "expiration": "2010-12-31 00:00:00"}`
+)

--- a/payload.go
+++ b/payload.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/gravitational/license/constants"
+
+	sigar "github.com/cloudfoundry/gosigar"
+	aws "github.com/gravitational/gravity/lib/cloudprovider/aws/service"
+	"github.com/gravitational/trace"
+)
+
+// Payload is custom information that gets encoded into licenses.
+//
+// For some customers JSON-formatted payload serves as a license itself.
+type Payload struct {
+	// ClusterID is vendor-specific cluster ID
+	ClusterID string `json:"cluster_id,omitempty"`
+	// Expiration is expiration time for the license
+	Expiration time.Time `json:"expiration,omitempty"`
+	// MaxNodes is maximum number of nodes the license allows
+	MaxNodes int `json:"max_nodes,omitempty"`
+	// MaxCores is maximum number of CPUs per node the license allows
+	MaxCores int `json:"max_cores,omitempty"`
+	// Company is the company name the license is generated for
+	Company string `json:"company,omitempty"`
+	// Person is the name of the person the license is generated for
+	Person string `json:"person,omitempty"`
+	// Email is the email of the person the license is generated for
+	Email string `json:"email,omitempty"`
+	// Metadata is an arbitrary customer metadata
+	Metadata string `json:"metadata,omitempty"`
+	// ProductName is the name of the product the license is for
+	ProductName string `json:"product_name,omitempty"`
+	// ProductVersion is the product version
+	ProductVersion string `json:"product_version,omitempty"`
+	// EncryptionKey is the passphrase for decoding encrypted packages
+	EncryptionKey []byte `json:"encryption_key,omitempty"`
+	// Signature is vendor-specific signature
+	Signature string `json:"signature,omitempty"`
+	// Shutdown indicates whether the app should be stopped when the license expires
+	Shutdown bool `json:"shutdown,omitempty"`
+}
+
+// UnmarshalJSON is a custom JSON unmarshaler for payload.
+func (p *Payload) UnmarshalJSON(data []byte) error {
+	// first try to unmarshal as a "normal" payload object which is
+	// how we store our own license details
+	var unmarshaled payload
+	err := json.Unmarshal(data, &unmarshaled)
+	if err == nil {
+		*p = Payload(unmarshaled)
+		return nil
+	}
+	// if that failed, use custom unmarshaler with the format defined
+	// below that some of vendors use
+	var aux unmarshalFormat
+	err = json.Unmarshal(data, &aux)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.Expiration, err = time.Parse(constants.LicenseTimeFormat, aux.Expiration)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.MaxNodes = 0
+	if aux.MaxNodes != "" {
+		p.MaxNodes, err = strconv.Atoi(aux.MaxNodes)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	p.MaxCores = 0
+	if aux.MaxCores != "" {
+		p.MaxCores, err = strconv.Atoi(aux.MaxCores)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	p.ClusterID = aux.ClusterID
+	p.Company = aux.Company
+	p.Person = aux.Person
+	p.Email = aux.Email
+	p.Signature = aux.Signature
+	p.Shutdown = aux.Shutdown
+	return nil
+}
+
+// payload is used to avoid recursion when unmarshaling
+type payload Payload
+
+// unmarshalFormat specifies how to unmarshal license payload from a JSON string.
+//
+// It's needed because payload serves as a license itself for some customers and they
+// have strict rules of what the string version of license should look like.
+type unmarshalFormat struct {
+	ClusterID  string `json:"cluster_id,omitempty"`
+	Expiration string `json:"expiration,omitempty"`
+	MaxNodes   string `json:"maxnodes,omitempty"`
+	MaxCores   string `json:"maxcores,omitempty"`
+	Company    string `json:"company,omitempty"`
+	Person     string `json:"person,omitempty"`
+	Email      string `json:"email,omitempty"`
+	Signature  string `json:"signature,omitempty"`
+	Shutdown   bool   `json:"shutdown,omitempty"`
+}
+
+// parsePayload attemps to parse the provided license string as a license payload.
+func parsePayload(license string) (License, error) {
+	var p Payload
+	err := json.Unmarshal([]byte(license), &p)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &p, nil
+}
+
+// Verify verifies that the expiration time is not in the past.
+func (p Payload) Verify(_ []byte) error {
+	if p.Expiration.Before(time.Now().UTC()) {
+		return trace.BadParameter("the license has expired")
+	}
+	return nil
+}
+
+// GetPayload returns payload.
+func (p Payload) GetPayload() Payload {
+	return p
+}
+
+// CheckCount checks if the license supports the provided number of servers.
+func (p Payload) CheckCount(count int) error {
+	if p.MaxNodes != 0 && count > p.MaxNodes {
+		return trace.BadParameter(
+			"the license allows maximum of %v nodes, requested: %v", p.MaxNodes, count)
+	}
+	return nil
+}
+
+// CheckCPU checks if the license supports the provided number of CPUs.
+func (p Payload) CheckCPU(cpu sigar.CpuList) error {
+	count := len(cpu.List)
+	if p.MaxCores != 0 && count > p.MaxCores {
+		return trace.BadParameter(
+			"the license allows maximum of %v CPUs, requested: %v", p.MaxCores, count)
+	}
+	return nil
+}
+
+// CheckInstanceTypes checks if the license supports all of the provided AWS instance types.
+func (p Payload) CheckInstanceTypes(instanceTypes []string) error {
+	supported := make(map[string]struct{})
+	for _, t := range p.FilterInstanceTypes(instanceTypes) {
+		supported[t] = struct{}{}
+	}
+	for _, t := range instanceTypes {
+		if _, ok := supported[t]; !ok {
+			return trace.BadParameter(
+				"the license does not support instance type: %v", t)
+		}
+	}
+	return nil
+}
+
+// FilterInstanceTypes retuns a subset of the provided AWS instance types supported by the license.
+func (p Payload) FilterInstanceTypes(instanceTypes []string) []string {
+	if p.MaxCores == 0 {
+		return instanceTypes
+	}
+	supported := []string{}
+	for _, t := range instanceTypes {
+		for _, awsT := range aws.EC2InstanceTypes {
+			if awsT.Name == t && awsT.CPU <= p.MaxCores {
+				supported = append(supported, t)
+			}
+		}
+	}
+	return supported
+}

--- a/payload_test.go
+++ b/payload_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package license
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	sigar "github.com/cloudfoundry/gosigar"
+	. "gopkg.in/check.v1"
+)
+
+type PayloadSuite struct{}
+
+var _ = Suite(&PayloadSuite{})
+
+func (s *PayloadSuite) TestMarshalUnmarshal(c *C) {
+	p := Payload{
+		ClusterID:  "cluster-123",
+		Expiration: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		MaxNodes:   3,
+		MaxCores:   8,
+	}
+
+	marshaled, err := json.Marshal(p)
+	c.Assert(err, IsNil)
+
+	// make sure expiration, max nodes and max cores were marshaled as strings
+	c.Assert(strings.Contains(string(marshaled), `"cluster-123"`), Equals, true)
+	c.Assert(strings.Contains(string(marshaled), `"2000-01-01T00:00:00Z"`), Equals, true)
+	c.Assert(strings.Contains(string(marshaled), `3`), Equals, true)
+	c.Assert(strings.Contains(string(marshaled), `8`), Equals, true)
+
+	var unmarshaled Payload
+	err = json.Unmarshal(marshaled, &unmarshaled)
+	c.Assert(err, IsNil)
+
+	// make sure we unmarshaled it correctly
+	c.Assert(unmarshaled.ClusterID, Equals, "cluster-123")
+	c.Assert(unmarshaled.Expiration, Equals, time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC))
+	c.Assert(unmarshaled.MaxNodes, Equals, 3)
+	c.Assert(unmarshaled.MaxCores, Equals, 8)
+}
+
+func (s *PayloadSuite) TestUnmarshalCustomerLicense(c *C) {
+	l := `{"cluster_id": "4fea07ba370f389b", "expiration": "2016-12-31 00:00:00", "maxnodes": "17", "maxcores": "32"}`
+
+	var unmarshaled Payload
+	err := json.Unmarshal([]byte(l), &unmarshaled)
+	c.Assert(err, IsNil)
+
+	// make sure it got unmarshaled correctly
+	c.Assert(unmarshaled.ClusterID, Equals, "4fea07ba370f389b")
+	c.Assert(unmarshaled.Expiration, Equals, time.Date(2016, time.December, 31, 0, 0, 0, 0, time.UTC))
+	c.Assert(unmarshaled.MaxNodes, Equals, 17)
+	c.Assert(unmarshaled.MaxCores, Equals, 32)
+}
+
+func (s *PayloadSuite) TestMarshalUnmarshalOptional(c *C) {
+	p := Payload{
+		ClusterID:  "cluster-123",
+		Expiration: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	marshaled, err := json.Marshal(p)
+	c.Assert(err, IsNil)
+
+	// no zero values for max nodes and other fields should be present
+	c.Assert(string(marshaled), Equals, `{"cluster_id":"cluster-123","expiration":"2000-01-01T00:00:00Z"}`)
+
+	var unmarshaled Payload
+	err = json.Unmarshal(marshaled, &unmarshaled)
+	c.Assert(err, IsNil)
+
+	// max nodes and max cores should be 0
+	c.Assert(unmarshaled.MaxNodes, Equals, 0)
+	c.Assert(unmarshaled.MaxCores, Equals, 0)
+}
+
+func (s *PayloadSuite) TestCheckCount(c *C) {
+	tcs := []struct {
+		name     string
+		maxNodes int
+		count    int
+		ok       bool
+	}{
+		{
+			name:     "license with max nodes 10 allows 3 nodes",
+			maxNodes: 10,
+			count:    3,
+			ok:       true,
+		},
+		{
+			name:     "license with max nodes 1 prohibits 3 nodes",
+			maxNodes: 1,
+			count:    3,
+			ok:       false,
+		},
+		{
+			name:     "license with max nodes 3 allows 3 nodes",
+			maxNodes: 3,
+			count:    3,
+			ok:       true,
+		},
+		{
+			name:     "license with max nodes 0 allows any number of nodes",
+			maxNodes: 0,
+			count:    3,
+			ok:       true,
+		},
+	}
+	for _, tc := range tcs {
+		err := Payload{MaxNodes: tc.maxNodes}.CheckCount(tc.count)
+		c.Assert(err == nil, Equals, tc.ok, Commentf("%v failed", tc.name))
+	}
+}
+
+func (s *PayloadSuite) TestCheckCPU(c *C) {
+	tcs := []struct {
+		name     string
+		maxCores int
+		count    int
+		ok       bool
+	}{
+		{
+			name:     "license with max cores 10 allows 3 CPUs",
+			maxCores: 10,
+			count:    3,
+			ok:       true,
+		},
+		{
+			name:     "license with max cores 1 prohibits 3 CPUs",
+			maxCores: 1,
+			count:    3,
+			ok:       false,
+		},
+		{
+			name:     "license with max cores 3 allows 3 CPUs",
+			maxCores: 3,
+			count:    3,
+			ok:       true,
+		},
+		{
+			name:     "license with max cores 0 allows any number of CPUs",
+			maxCores: 0,
+			count:    3,
+			ok:       true,
+		},
+	}
+	for _, tc := range tcs {
+		cpus := sigar.CpuList{}
+		for i := 0; i < tc.count; i++ {
+			cpus.List = append(cpus.List, sigar.Cpu{})
+		}
+		err := Payload{MaxCores: tc.maxCores}.CheckCPU(cpus)
+		c.Assert(err == nil, Equals, tc.ok, Commentf("%v failed", tc.name))
+	}
+}
+
+func (s *PayloadSuite) TestCheckInstanceTypes(c *C) {
+	tcs := []struct {
+		name          string
+		maxCores      int
+		instanceTypes []string
+		ok            bool
+	}{
+		{
+			name:          "license with max cores 2 does not support m3.l, m3.xl and c3.xl",
+			maxCores:      2,
+			instanceTypes: []string{"m3.large", "m3.xlarge", "c3.xlarge"},
+			ok:            false,
+		},
+		{
+			name:          "license with max cores 4 supports all of m3.l, m3.xl and c3.xl",
+			maxCores:      4,
+			instanceTypes: []string{"m3.large", "m3.xlarge", "c3.xlarge"},
+			ok:            true,
+		},
+		{
+			name:          "license with max cores 4 does not support c3.2xl",
+			maxCores:      4,
+			instanceTypes: []string{"c3.2xlarge", "i2.2xlarge"},
+			ok:            false,
+		},
+		{
+			name:          "license with max cores 0 supports all instance types",
+			maxCores:      0,
+			instanceTypes: []string{"m3.large", "c3.2xlarge", "i2.2xlarge"},
+			ok:            true,
+		},
+	}
+	for _, tc := range tcs {
+		err := Payload{MaxCores: tc.maxCores}.CheckInstanceTypes(tc.instanceTypes)
+		c.Assert(err == nil, Equals, tc.ok, Commentf("%v failed", tc.name))
+	}
+}
+
+func (s *PayloadSuite) TestFilterInstanceTypes(c *C) {
+	tcs := []struct {
+		name          string
+		maxCores      int
+		instanceTypes []string
+		expected      []string
+	}{
+		{
+			name:          "license with max cores 2 supports only m3.l",
+			maxCores:      2,
+			instanceTypes: []string{"m3.large", "m3.xlarge", "c3.xlarge"},
+			expected:      []string{"m3.large"},
+		},
+		{
+			name:          "license with max cores 4 supports all of m3.l, m3.xl and c3.xl",
+			maxCores:      4,
+			instanceTypes: []string{"m3.large", "m3.xlarge", "c3.xlarge"},
+			expected:      []string{"m3.large", "m3.xlarge", "c3.xlarge"},
+		},
+		{
+			name:          "license with max cores 4 does not support c3.2xl and i2.2xl",
+			maxCores:      4,
+			instanceTypes: []string{"c3.2xlarge", "i2.2xlarge"},
+			expected:      []string{},
+		},
+		{
+			name:          "license with max cores 0 supports all instance types",
+			maxCores:      0,
+			instanceTypes: []string{"m3.large", "c3.2xlarge", "i2.2xlarge"},
+			expected:      []string{"m3.large", "c3.2xlarge", "i2.2xlarge"},
+		},
+	}
+	for _, tc := range tcs {
+		filtered := Payload{MaxCores: tc.maxCores}.FilterInstanceTypes(tc.instanceTypes)
+		c.Assert(filtered, DeepEquals, tc.expected, Commentf("%v failed", tc.name))
+	}
+}


### PR DESCRIPTION
This will be reused in the control plane service for Teleport Pro project.
