### PR TITLE
Add an RSA key parser that handles PKCS1 and PKCS8

### DIFF
--- a/generate/internal/parse/privatekey.go
+++ b/generate/internal/parse/privatekey.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parse
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	pkcs1PrivateKeyType = "RSA PRIVATE KEY"
+	pkcs8PrivateKeyType = "PRIVATE KEY"
+)
+
+// RSAPrivateKey parses an RSA private key given key PEM block.
+func RSAPrivateKey(keyPEM []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		return nil, trace.NotFound("no PEM block found")
+	}
+
+	switch block.Type {
+	case pkcs1PrivateKeyType, pkcs8PrivateKeyType:
+	default:
+		return nil, trace.BadParameter("unexpected private key PEM type %q", block.Type)
+	}
+
+	// The DER format doesn't always exactly match the PEM header, various
+	// versions of Teleport and OpenSSL have been guilty of writing PKCS#8
+	// data into an "RSA PRIVATE KEY" block or vice-versa, so we just try
+	// parsing every DER format. This matches the behavior of [tls.X509KeyPair].
+	var preferredErr error
+	if priv, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		switch key := priv.(type) {
+		case *rsa.PrivateKey:
+			return key, nil
+		default:
+			return nil, trace.BadParameter("expected an RSA private key but found %T", key)
+		}
+	} else if block.Type == pkcs8PrivateKeyType {
+		preferredErr = err
+	}
+	if priv, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return priv, nil
+	} else if block.Type == pkcs1PrivateKeyType {
+		preferredErr = err
+	}
+
+	// If all parse functions returned an error, preferedErr is
+	// guaranteed to be set to the error from the parse function that
+	// usually matches the PEM block type.
+	return nil, trace.Wrap(preferredErr, "parsing private key PEM")
+}

--- a/generate/newlicense.go
+++ b/generate/newlicense.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/license/authority"
 	"github.com/gravitational/license/constants"
+	"github.com/gravitational/license/generate/internal/parse"
 
 	"github.com/gravitational/trace"
 )
@@ -137,16 +138,7 @@ func (i *NewLicenseInfo) CACertificate() (*x509.Certificate, error) {
 }
 
 func (i *NewLicenseInfo) SigningKey() (*rsa.PrivateKey, error) {
-	block, _ := pem.Decode(i.TLSKeyPair.KeyPEM)
-	if block == nil {
-		return nil, trace.BadParameter("missing or invalid CA private key PEM")
-	}
-
-	if block.Type != constants.RSAPrivateKeyPEMBlock {
-		return nil, trace.BadParameter("invalid PEM block: %v", block.Type)
-	}
-
-	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	privateKey, err := parse.RSAPrivateKey(i.TLSKeyPair.KeyPEM)
 	return privateKey, trace.Wrap(err)
 }
 


### PR DESCRIPTION
It turns out we have some PKCS8 keys in use that are placed in PEM blocks that look like PKCS1. Add a parse function that tries both types instead of trusting the PEM block type.